### PR TITLE
Add descriptive alt text to landing page images

### DIFF
--- a/src/components/Cards/TravelStoryCard.jsx
+++ b/src/components/Cards/TravelStoryCard.jsx
@@ -43,7 +43,7 @@ const TravelStoryCard = ({
             >
                 <img 
                     src={imgUrl} 
-                    alt={title} 
+                    alt={`Travel story image: ${title}`}
                     className='w-full h-full object-cover transition-transform duration-300' 
                     onClick={onClick} 
                     loading="lazy"

--- a/src/pages/hero/Hero.jsx
+++ b/src/pages/hero/Hero.jsx
@@ -61,7 +61,7 @@ const Hero = () => {
                                 <img
                                     className="w-auto h-12 cursor-pointer"
                                     src={logo}
-                                    alt="logo"
+                                    alt="TravelBook logo"
                                     onClick={() => navigate("/")}
                                 />
                             </Link>


### PR DESCRIPTION
### What this PR does
- Adds meaningful and descriptive `alt` text to images on the landing page
- Improves accessibility and screen reader support
- Enhances SEO and overall inclusiveness

### Why this change is needed
- Several images had missing or non-descriptive alt attributes
- Improves compliance with accessibility best practices

### Related Issue
Closes #112